### PR TITLE
Revert "Forced snapshots of micrometer & micrometer-tracing"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,15 +29,14 @@
 
     <properties>
         <java.version>17</java.version>
-        <micrometer-bom.version>1.10.0-SNAPSHOT</micrometer-bom.version>
-        <micrometer-tracing-bom.version>1.0.0-SNAPSHOT</micrometer-tracing-bom.version>
+        <micrometer-tracing-bom.version>1.0.0-M8</micrometer-tracing-bom.version>
         <junit.version>5.8.2</junit.version>
         <mockito.version>4.6.1</mockito.version>
         <assertj.version>3.23.1</assertj.version>
         <spring-javaformat.version>0.0.34</spring-javaformat.version>
 
         <!-- Docs -->
-        <micrometer-docs-generator.version>1.0.0-SNAPSHOT</micrometer-docs-generator.version>
+        <micrometer-docs-generator.version>1.0.0-M7</micrometer-docs-generator.version>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
         <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
@@ -203,13 +202,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>io.micrometer</groupId>
-                <artifactId>micrometer-bom</artifactId>
-                <version>${micrometer-bom.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <dependency>
                 <groupId>io.micrometer</groupId>
                 <artifactId>micrometer-tracing-bom</artifactId>


### PR DESCRIPTION
Reverts jdbc-observations/datasource-micrometer#4

Boot does not use Micrometer SNAPSHOT yet, need to wait until Boot uses micrometer SNAPSHOT.