### PR TITLE
Add DATASOURCE_DRIVER and DATASOURCE_POOL keys to all observations

### DIFF
--- a/datasource-micrometer/src/main/java/net/ttddyy/observation/tracing/HikariJdbcObservationFilter.java
+++ b/datasource-micrometer/src/main/java/net/ttddyy/observation/tracing/HikariJdbcObservationFilter.java
@@ -38,11 +38,11 @@ public class HikariJdbcObservationFilter implements ObservationFilter {
 
 	@Override
 	public Context map(Context context) {
-		if (!(context instanceof ConnectionContext)) {
+		if (!(context instanceof DataSourceBaseContext)) {
 			return context;
 		}
 
-		ConnectionContext connectionContext = (ConnectionContext) context;
+		DataSourceBaseContext connectionContext = (DataSourceBaseContext) context;
 		DataSource dataSource = connectionContext.getDataSource();
 
 		HikariDataSource hikariDataSource;

--- a/datasource-micrometer/src/test/java/net/ttddyy/observation/tracing/HikariJdbcObservationFilterTests.java
+++ b/datasource-micrometer/src/test/java/net/ttddyy/observation/tracing/HikariJdbcObservationFilterTests.java
@@ -37,14 +37,12 @@ import static org.mockito.Mockito.mock;
  */
 class HikariJdbcObservationFilterTests {
 
+	public static final String DRIVER = "my-driver";
+	public static final String POOL = "my-pool";
+
 	@Test
 	void filter() throws Exception {
-		HikariDataSource hikariDataSource = mock(HikariDataSource.class);
-		given(hikariDataSource.getDriverClassName()).willReturn("my-driver");
-		given(hikariDataSource.getPoolName()).willReturn("my-pool");
-		DataSource dataSource = mock(DataSource.class);
-		given(dataSource.isWrapperFor(HikariDataSource.class)).willReturn(true);
-		given(dataSource.unwrap(HikariDataSource.class)).willReturn(hikariDataSource);
+		DataSource dataSource = givenHikariDataSource();
 
 		ConnectionContext context = new ConnectionContext();
 		context.setDataSource(dataSource);
@@ -52,9 +50,7 @@ class HikariJdbcObservationFilterTests {
 		HikariJdbcObservationFilter filter = new HikariJdbcObservationFilter();
 		Context result = filter.map(context);
 
-		ObservationContextAssert.assertThat(result)
-				.hasLowCardinalityKeyValue(ConnectionKeyNames.DATASOURCE_DRIVER.asString(), "my-driver")
-				.hasLowCardinalityKeyValue(ConnectionKeyNames.DATASOURCE_POOL.asString(), "my-pool");
+		assertObservationHasHikariKeys(result);
 	}
 
 	@Test
@@ -87,12 +83,45 @@ class HikariJdbcObservationFilterTests {
 	}
 
 	@Test
-	void nonConnectionContext() {
+	void queryContext() throws Exception {
+		DataSource dataSource = givenHikariDataSource();
+
 		QueryContext context = new QueryContext();
+		context.setDataSource(dataSource);
+
 		HikariJdbcObservationFilter filter = new HikariJdbcObservationFilter();
 		Context result = filter.map(context);
 
-		assertNotApplicableContext(context, result);
+		assertObservationHasHikariKeys(result);
+	}
+
+	@Test
+	void resultSetContext() throws Exception {
+		DataSource dataSource = givenHikariDataSource();
+
+		ResultSetContext context = new ResultSetContext();
+		context.setDataSource(dataSource);
+
+		HikariJdbcObservationFilter filter = new HikariJdbcObservationFilter();
+		Context result = filter.map(context);
+
+		assertObservationHasHikariKeys(result);
+	}
+
+	private static void assertObservationHasHikariKeys(Context result) {
+		ObservationContextAssert.assertThat(result)
+				.hasLowCardinalityKeyValue(ConnectionKeyNames.DATASOURCE_DRIVER.asString(), "my-driver")
+				.hasLowCardinalityKeyValue(ConnectionKeyNames.DATASOURCE_POOL.asString(), "my-pool");
+	}
+
+	private static DataSource givenHikariDataSource() throws SQLException {
+		HikariDataSource hikariDataSource = mock(HikariDataSource.class);
+		given(hikariDataSource.getDriverClassName()).willReturn(DRIVER);
+		given(hikariDataSource.getPoolName()).willReturn(POOL);
+		DataSource dataSource = mock(DataSource.class);
+		given(dataSource.isWrapperFor(HikariDataSource.class)).willReturn(true);
+		given(dataSource.unwrap(HikariDataSource.class)).willReturn(hikariDataSource);
+		return dataSource;
 	}
 
 	private void assertNotApplicableContext(Context original, Context result) {


### PR DESCRIPTION
I think that DATASOURCE_DRIVER and DATASOURCE_POOL should apply to all observations. Without this keys we cannot separate metrics in Prometheus when application have multiple datasources. ResutSet/Query metrics without separation by pool doesn't make sense. 