### PR TITLE
Fix typography at sample code in docs

### DIFF
--- a/docs/src/main/asciidoc/getting-started.adoc
+++ b/docs/src/main/asciidoc/getting-started.adoc
@@ -113,7 +113,7 @@ To setup the observation for JDBC operations, xref:howto.adoc#how-to-instrument-
 ObservationRegistry observationRegistry = ObservationRegistry.create();
 ObservationConfig observationConfig = observationRegistry.observationConfig();
 observationConfig.observationHandler(new ConnectionTracingObservationHandler(tracer));
-observationConfig.observationHandler(new QueryTracingObservationHandler(tracer);
+observationConfig.observationHandler(new QueryTracingObservationHandler(tracer));
 observationConfig.observationHandler(new ResultSetTracingObservationHandler(tracer));
 //  add other necessary handlers
 

--- a/docs/src/main/asciidoc/howto.adoc
+++ b/docs/src/main/asciidoc/howto.adoc
@@ -40,7 +40,7 @@ There are 3 tracing observation handlers that react to the observations from `Da
 ----
 ObservationRegistry registry = ...
 registry.observationConfig().observationHandler(new ConnectionTracingObservationHandler(tracer));
-registry.observationConfig().observationHandler(new QueryTracingObservationHandler(tracer);
+registry.observationConfig().observationHandler(new QueryTracingObservationHandler(tracer));
 registry.observationConfig().observationHandler(new ResultSetTracingObservationHandler(tracer));
 ----
 


### PR DESCRIPTION
I find some typographies at sample code in docs. I fixed it.