### PR TITLE
Align versions with Spring and Micrometer milestone builds

### DIFF
--- a/datasource-micrometer-bom/pom.xml
+++ b/datasource-micrometer-bom/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>net.ttddyy.observation</groupId>
         <artifactId>datasource-micrometer-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>2.0.0-M2-SNAPSHOT</version>
     </parent>
 
     <artifactId>datasource-micrometer-bom</artifactId>
@@ -34,12 +34,12 @@
             <dependency>
                 <groupId>net.ttddyy.observation</groupId>
                 <artifactId>datasource-micrometer</artifactId>
-                <version>1.2.0-SNAPSHOT</version>
+                <version>2.0.0-M2-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.ttddyy.observation</groupId>
                 <artifactId>datasource-micrometer-spring-boot</artifactId>
-                <version>1.2.0-SNAPSHOT</version>
+                <version>2.0.0-M2-SNAPSHOT</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/datasource-micrometer-spring-boot/pom.xml
+++ b/datasource-micrometer-spring-boot/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>net.ttddyy.observation</groupId>
         <artifactId>datasource-micrometer-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>2.0.0-M2-SNAPSHOT</version>
     </parent>
 
     <artifactId>datasource-micrometer-spring-boot</artifactId>

--- a/datasource-micrometer/pom.xml
+++ b/datasource-micrometer/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>net.ttddyy.observation</groupId>
         <artifactId>datasource-micrometer-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>2.0.0-M2-SNAPSHOT</version>
     </parent>
 
     <artifactId>datasource-micrometer</artifactId>
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>2.1.214</version>
+            <version>2.3.232</version>
             <scope>test</scope>
         </dependency>
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>net.ttddyy.observation</groupId>
         <artifactId>datasource-micrometer-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>2.0.0-M2-SNAPSHOT</version>
     </parent>
 
     <artifactId>datasource-micrometer-docs</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,44 +22,44 @@
     <groupId>net.ttddyy.observation</groupId>
     <artifactId>datasource-micrometer-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>2.0.0-M2-SNAPSHOT</version>
     <name>datasource-micrometer-parent</name>
     <description>Micrometer observation for JDBC</description>
     <url>https://github.com/jdbc-observations/datasource-micrometer</url>
 
     <properties>
         <java.version>17</java.version>
-        <micrometer-bom.version>1.14.8</micrometer-bom.version>
-        <micrometer-tracing-bom.version>1.4.7</micrometer-tracing-bom.version>
-        <spring-javaformat.version>0.0.43</spring-javaformat.version>
+        <micrometer-bom.version>1.16.0-M3</micrometer-bom.version>
+        <micrometer-tracing-bom.version>1.6.0-M3</micrometer-tracing-bom.version>
+        <spring-javaformat.version>0.0.47</spring-javaformat.version>
 
         <!-- Tests  -->
-        <junit.version>5.11.4</junit.version>
-        <mockito.version>5.14.2</mockito.version>
-        <assertj.version>3.26.3</assertj.version>
+        <junit.version>5.13.4</junit.version>
+        <mockito.version>5.19.0</mockito.version>
+        <assertj.version>3.27.4</assertj.version>
 
         <!-- datasource-micrometer module -->
-        <datasource-proxy.version>1.10.1</datasource-proxy.version>
+        <datasource-proxy.version>1.11.0</datasource-proxy.version>
 
         <!-- datasource-micrometer-spring-boot module -->
         <spring-boot.version>4.0.0-M2</spring-boot.version>
 
         <!-- Docs -->
         <micrometer-docs-generator.version>1.0.4</micrometer-docs-generator.version>
-        <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
+        <asciidoctor.maven.plugin.version>3.2.0</asciidoctor.maven.plugin.version>
         <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
-        <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
-        <asciidoctorj.version>2.5.1</asciidoctorj.version>
-        <jruby-complete.version>9.2.19.0</jruby-complete.version>
+        <exec-maven-plugin.version>3.5.1</exec-maven-plugin.version>
+        <asciidoctorj.version>3.0.0</asciidoctorj.version>
+        <jruby-complete.version>10.0.2.0</jruby-complete.version>
         <ant-contrib.version>1.0b3</ant-contrib.version>
         <antelopetasks.version>3.2.10</antelopetasks.version>
         <ant-nodeps.version>1.8.1</ant-nodeps.version>
-        <script-commons-logging.version>1.2</script-commons-logging.version>
-        <script-spring-core.version>5.3.22</script-spring-core.version>
-        <script-jackson-databind.version>2.13.3</script-jackson-databind.version>
+        <script-commons-logging.version>1.3.5</script-commons-logging.version>
+        <script-spring-core.version>7.0.0-M8</script-spring-core.version>
+        <script-jackson-databind.version>2.20.0</script-jackson-databind.version>
         <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
 
-        <maven-deploy-plugin.version>3.0.0</maven-deploy-plugin.version>
+        <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
     </properties>
 
     <modules>
@@ -79,17 +79,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.5.4</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.14.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.4.1</version>
+                <version>3.11.3</version>
                 <configuration>
                     <skippedModules>datasource-micrometer-docs</skippedModules>
                     <notimestamp>true</notimestamp>
@@ -113,17 +113,17 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.2.1</version>
+                    <version>3.3.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-gpg-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>3.2.8</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jreleaser</groupId>
                     <artifactId>jreleaser-maven-plugin</artifactId>
-                    <version>1.18.0</version>
+                    <version>1.20.0</version>
                 </plugin>
                 <plugin>
                     <groupId>pl.project13.maven</groupId>
@@ -203,7 +203,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>flatten-maven-plugin</artifactId>
-                    <version>1.3.0</version>
+                    <version>1.7.2</version>
                     <configuration>
                         <flattenMode>ossrh</flattenMode>
                         <pomElements>


### PR DESCRIPTION
Set versions for

- micrometer (1.16.0-M3)
- micrometer-tracing (1.6.0-M3)
- spring-core (7.0.0-M8)
- and bump other versions to latest

Suggest using new major version 2.0.0 and use Milestone M2 suffix to align with build with Spring Boot 4.0 Milestone numbering