### PR TITLE
fix: ensure Observation.Scope is closed even if ExecutionInfo loses its state

### DIFF
--- a/datasource-micrometer/src/main/java/net/ttddyy/observation/tracing/DataSourceObservationListener.java
+++ b/datasource-micrometer/src/main/java/net/ttddyy/observation/tracing/DataSourceObservationListener.java
@@ -188,7 +188,11 @@ public class DataSourceObservationListener implements QueryExecutionListener, Me
 		Observation.Scope scopeToUse = executionInfo.getCustomValue(Observation.Scope.class.getName(),
 				Observation.Scope.class);
 		if (scopeToUse == null) {
-			return;
+			Observation.Scope scope = this.observationRegistrySupplier.get().getCurrentObservationScope();
+			if (scope == null) {
+				return;
+			}
+			scopeToUse = scope;
 		}
 		Observation observation = scopeToUse.getCurrentObservation();
 		try (Observation.Scope scope = scopeToUse) {
@@ -209,7 +213,9 @@ public class DataSourceObservationListener implements QueryExecutionListener, Me
 				}
 				QueryContext queryContext = executionInfo.getCustomValue(QueryContext.class.getName(),
 						QueryContext.class);
-				queryContext.setAffectedRowCount(affectedRowCount);
+				if (queryContext != null) {
+					queryContext.setAffectedRowCount(affectedRowCount);
+				}
 			}
 		}
 		finally {


### PR DESCRIPTION
## Description

This PR fixes a potential memory leak in `DataSourceObservationListener` that can occur during query execution when `ExecutionInfo` loses its context (for example, due to connection eviction or forced closure).

It addresses the issue reported in #91 

---

## Changes

- **Fallback logic in `stopQueryObservation`**  
  If the `Observation.Scope` cannot be retrieved from `ExecutionInfo`, the listener now performs a defensive cleanup by ensuring that any active observation scope associated with the current thread is properly closed. This guarantees that the scope opened in `beforeQuery` is always closed, preventing `ThreadLocal` leaks.

- **Null safety improvement**  
  Added a null check for `QueryContext` before calling `setAffectedRowCount` to prevent a potential `NullPointerException` in edge cases where the context may be missing.

- **Test case added**  
  Added `memoryLeakWhenConnectionForciblyClosedAndExecutionInfoLost` to `DataSourceObservationListenerTests`. 
This test simulates a scenario where `ExecutionInfo` fails to return the stored scope and verifies that the fallback logic correctly cleans up the observation registry.

---

## Verification

- Added a new unit test:  
  `DataSourceObservationListenerTests#memoryLeakWhenConnectionForciblyClosedAndExecutionInfoLost`
- Verified that all tests pass by running:

  ```bash
  ./mvnw test
