### PR TITLE
Add jdbc.hikari.enabled property for Hikari observation

### DIFF
--- a/datasource-micrometer-spring-boot/src/main/java/net/ttddyy/observation/boot/autoconfigure/DataSourceObservationAutoConfiguration.java
+++ b/datasource-micrometer-spring-boot/src/main/java/net/ttddyy/observation/boot/autoconfigure/DataSourceObservationAutoConfiguration.java
@@ -164,6 +164,7 @@ public class DataSourceObservationAutoConfiguration {
 
 	@Configuration(proxyBeanMethods = false)
 	@ConditionalOnClass(name = "com.zaxxer.hikari.HikariDataSource")
+	@ConditionalOnProperty(prefix = "jdbc.hikari", name = "enabled", havingValue = "true", matchIfMissing = true)
 	static class Hikari {
 
 		@Bean

--- a/datasource-micrometer-spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/datasource-micrometer-spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -21,6 +21,13 @@
       "sourceType": "net.ttddyy.observation.boot.autoconfigure.opentelemetry.DataSourceObservationOpenTelemetryAutoConfiguration"
     },
     {
+      "name": "jdbc.hikari.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether to enable Hikari-specific observation support.",
+      "defaultValue": true,
+      "sourceType": "net.ttddyy.observation.boot.autoconfigure.DataSourceObservationAutoConfiguration"
+    },
+    {
       "name": "jdbc.opentelemetry.spans.enabled",
       "type": "java.lang.Boolean",
       "description": "Whether to enable support for OpenTelemetry Semantic Conventions for spans.",

--- a/datasource-micrometer-spring-boot/src/test/java/net/ttddyy/observation/boot/autoconfigure/DataSourceObservationAutoConfigurationIntegrationTests.java
+++ b/datasource-micrometer-spring-boot/src/test/java/net/ttddyy/observation/boot/autoconfigure/DataSourceObservationAutoConfigurationIntegrationTests.java
@@ -29,6 +29,7 @@ import io.micrometer.tracing.test.simple.SpansAssert;
 import net.ttddyy.dsproxy.proxy.ProxyJdbcObject;
 import net.ttddyy.dsproxy.support.ProxyDataSource;
 import net.ttddyy.observation.tracing.DataSourceObservationListener;
+import net.ttddyy.observation.tracing.HikariJdbcObservationFilter;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -37,6 +38,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
@@ -184,6 +186,49 @@ class DataSourceObservationAutoConfigurationIntegrationTests {
 			// @formatter:on
 			args = "--debug", classes = { MyDataSourceConfiguration.class })
 	class WithManualDataSourceBean extends TestCaseBase {
+
+	}
+
+	@Nested
+	@SpringBootTest(
+	// @formatter:off
+			properties = {
+					"spring.autoconfigure.exclude=net.ttddyy.observation.boot.autoconfigure.opentelemetry.DataSourceObservationOpenTelemetryAutoConfiguration",
+					"jdbc.hikari.enabled=false",
+
+					// embedded DB
+					"spring.datasource.url=jdbc:h2:mem:testdb-hikari-disabled",
+					"spring.datasource.driverClassName=org.h2.Driver",
+					"spring.datasource.username=sa",
+
+					// populate db
+					"spring.sql.init.schema-locations=classpath:itest-schema.sql",
+					"spring.sql.init.data-locations=classpath:itest-data.sql",
+
+					// tracing
+					"management.tracing.sampling.probability=1.0",
+
+					// specify query logging
+					"jdbc.datasource-proxy.logging=slf4j",
+					"jdbc.datasource-proxy.query.enable-logging=true",
+					"jdbc.datasource-proxy.query.log-level=DEBUG",
+					"jdbc.datasource-proxy.query.logger-name=my.query-logger",
+					"logging.level.my.query-logger=DEBUG",
+
+					// for debugging, log spans
+					"logging.level.brave.Tracer=INFO"
+			},
+	// @formatter:on
+			args = "--debug")
+	class WithHikariObservationDisabled extends TestCaseBase {
+
+		@Autowired
+		ApplicationContext applicationContext;
+
+		@Test
+		void disablesHikariObservationFilter() {
+			assertThat(this.applicationContext.getBeansOfType(HikariJdbcObservationFilter.class)).isEmpty();
+		}
 
 	}
 

--- a/datasource-micrometer-spring-boot/src/test/java/net/ttddyy/observation/boot/autoconfigure/DataSourceObservationAutoConfigurationTests.java
+++ b/datasource-micrometer-spring-boot/src/test/java/net/ttddyy/observation/boot/autoconfigure/DataSourceObservationAutoConfigurationTests.java
@@ -227,6 +227,20 @@ class DataSourceObservationAutoConfigurationTests {
 	}
 
 	@Test
+	void hikariDisabled() {
+		new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(DataSourceObservationAutoConfiguration.class))
+			.withPropertyValues("jdbc.hikari.enabled=false")
+			.withBean(ObservationRegistry.class, ObservationRegistry::create)
+			.withBean(Tracer.class, () -> mock(Tracer.class))
+			.withBean(CustomConnectionObservationConvention.class)
+			.run((context) -> {
+				assertThat(context).doesNotHaveBean(HikariJdbcObservationFilter.class);
+				assertThat(context).doesNotHaveBean(ObservationRegistryCustomizer.class);
+			});
+	}
+
+	@Test
 	void observationHandler() {
 		new ApplicationContextRunner()
 			.withConfiguration(AutoConfigurations.of(DataSourceObservationAutoConfiguration.class))

--- a/docs/src/main/asciidoc/howto.adoc
+++ b/docs/src/main/asciidoc/howto.adoc
@@ -103,6 +103,11 @@ listener.setIncludeParameterValues(true);
 
 Set the `jdbc.datasource-proxy.enabled` property to `false`.
 
+[[how-to-disable-hikari-observation]]
+=== How to Disable Hikari-specific Observation
+
+Set the `jdbc.hikari.enabled` property to `false`.
+
 [[how-to-choose-what-to-observe]]
 === How to Choose What To Observe
 

--- a/docs/src/main/asciidoc/using.adoc
+++ b/docs/src/main/asciidoc/using.adoc
@@ -35,7 +35,8 @@ ObservationRegistry registry = ...
 registry.observationConfig().observationFilter(new HikariJdbcObservationFilter());
 ----
 
-It is auto configured in `datasource-micrometer-spring-boot`.
+It is auto configured in `datasource-micrometer-spring-boot` and can be disabled with
+`jdbc.hikari.enabled=false`.
 
 [[using-features-remote-ip-and-port]]
 === Remote IP and Port
@@ -163,4 +164,3 @@ STOP Observation      | "jdbc.connection"  <==
 CLOSE Scope           | "http.server.requests"
 STOP Observation      | "http.server.requests"
 ----
-


### PR DESCRIPTION
Fixes #100

This changes the original approach based on maintainer feedback. Instead of extracting a separate Hikari auto-configuration class, it introduces `jdbc.hikari.enabled` and skips the Hikari-specific configuration when the property is set to `false`.

The change is now based on `1.4.x` and includes tests for the default enabled behavior and the explicit disabled case.